### PR TITLE
Cleanup main loop (dungeon.c)

### DIFF
--- a/src/bank.c
+++ b/src/bank.c
@@ -16,7 +16,7 @@
 #include "debug.h"
 #include "player.h"
 #include "variables.h"
-#include "dungeon.h"
+#include "main_loop.h"
 #include "io.h"
 #include "screen.h"
 #include "misc.h"

--- a/src/blackmarket.c
+++ b/src/blackmarket.c
@@ -12,7 +12,7 @@
 #include "configure.h"
 #include "constants.h"
 #include "debug.h"
-#include "dungeon.h"
+#include "main_loop.h"
 #include "magic.h"
 #include "pascal.h"
 #include "term.h"

--- a/src/blow.c
+++ b/src/blow.c
@@ -12,7 +12,7 @@
 #include "configure.h"
 #include "constants.h"
 #include "debug.h"
-#include "dungeon.h"
+#include "main_loop.h"
 #include "magic.h"
 #include "pascal.h"
 #include "player.h"

--- a/src/creature.c
+++ b/src/creature.c
@@ -12,7 +12,7 @@
 #include "configure.h"
 #include "constants.h"
 #include "debug.h"
-#include "dungeon.h"
+#include "main_loop.h"
 #include "magic.h"
 #include "pascal.h"
 #include "player.h"
@@ -32,6 +32,7 @@
 
 #define OBJ_RUNE_PROT 3000 /*{ Rune of protection resistance	} */
 
+typedef long mm_type[6];
 static const long mon_mult_adj = 7; // High value slows multiplication
 
 void check_mon_lite(long y, long x) {

--- a/src/eat.c
+++ b/src/eat.c
@@ -9,7 +9,7 @@
 #include "configure.h"
 #include "constants.h"
 #include "debug.h"
-#include "dungeon.h"
+#include "main_loop.h"
 #include "magic.h"
 #include "pascal.h"
 #include "player.h"

--- a/src/fighting_ranged.c
+++ b/src/fighting_ranged.c
@@ -4,7 +4,7 @@
 
 #include "boolean.h"
 #include "debug.h"
-#include "dungeon.h"
+#include "main_loop.h"
 #include "player.h"
 #include "variables.h"
 #include "desc.h"

--- a/src/inven.c
+++ b/src/inven.c
@@ -9,7 +9,7 @@
 #include "configure.h"
 #include "constants.h"
 #include "debug.h"
-#include "dungeon.h"
+#include "main_loop.h"
 #include "magic.h"
 #include "pascal.h"
 #include "player.h"

--- a/src/io.c
+++ b/src/io.c
@@ -12,7 +12,7 @@
 #include "configure.h"
 #include "constants.h"
 #include "debug.h"
-#include "dungeon.h"
+#include "main_loop.h"
 #include "graphics.h"
 #include "magic.h"
 #include "pascal.h"

--- a/src/magic.c
+++ b/src/magic.c
@@ -1,7 +1,7 @@
 #include <string.h>
 
 #include "debug.h"
-#include "dungeon.h"
+#include "main_loop.h"
 #include "player.h"
 #include "variables.h"
 #include "inven.h"

--- a/src/magic_arcane.c
+++ b/src/magic_arcane.c
@@ -1,4 +1,4 @@
-#include "dungeon.h"
+#include "main_loop.h"
 #include "player.h"
 #include "variables.h"
 #include "spells.h"

--- a/src/magic_chakra.c
+++ b/src/magic_chakra.c
@@ -9,7 +9,7 @@
 #include "configure.h"
 #include "constants.h"
 #include "debug.h"
-#include "dungeon.h"
+#include "main_loop.h"
 #include "magic.h"
 #include "pascal.h"
 #include "player.h"

--- a/src/magic_divine.c
+++ b/src/magic_divine.c
@@ -9,7 +9,7 @@
 #include "configure.h"
 #include "constants.h"
 #include "debug.h"
-#include "dungeon.h"
+#include "main_loop.h"
 #include "magic.h"
 #include "pascal.h"
 #include "player.h"

--- a/src/magic_nature.c
+++ b/src/magic_nature.c
@@ -9,7 +9,7 @@
 #include "configure.h"
 #include "constants.h"
 #include "debug.h"
-#include "dungeon.h"
+#include "main_loop.h"
 #include "magic.h"
 #include "pascal.h"
 #include "player.h"

--- a/src/magic_song.c
+++ b/src/magic_song.c
@@ -9,7 +9,7 @@
 #include "configure.h"
 #include "constants.h"
 #include "debug.h"
-#include "dungeon.h"
+#include "main_loop.h"
 #include "magic.h"
 #include "pascal.h"
 #include "player.h"

--- a/src/main.c
+++ b/src/main.c
@@ -21,7 +21,7 @@
 #include "stores.h"
 #include "variables.h"
 #include "death.h"
-#include "dungeon.h"
+#include "main_loop.h"
 #include "generate_dungeon/generate_dungeon.h"
 #include "port.h"
 

--- a/src/main_loop.c
+++ b/src/main_loop.c
@@ -44,7 +44,7 @@
 #include "random.h"
 #include "monsters.h"
 
-#include "dungeon.h"
+#include "main_loop.h"
 
 void C_print_known_spells();
 
@@ -57,17 +57,17 @@ static long old_chp;               /* { Detect change         } */
 static long old_cmana;             /* { Detect change         } */
 static boolean player_light;    /* { Player carrying light } */
 static boolean save_msg_flag;   /* { Msg flag after INKEY  } */
+static char s1[70];             /* { Summon item strings   } */
+static char s2[70];             /* { Summon item strings   } */
+static char s3[70];             /* { Summon item strings   } */
+static char s4[70];             /* { Summon item strings   } */
+static long i_summ_count;       /* { Summon item count	   } */
 
 float regen_amount;      /* { Regenerate hp and mana} */
 boolean moria_flag;      /* { Next level when true  } */
 boolean reset_flag;      /* { Do not move creatures } */
 boolean search_flag;     /* { Player is searching   } */
 boolean teleport_flag;   /* { Handle telport traps  } */
-char s1[70];             /* { Summon item strings   } */
-char s2[70];             /* { Summon item strings   } */
-char s3[70];             /* { Summon item strings   } */
-char s4[70];             /* { Summon item strings   } */
-long i_summ_count;       /* { Summon item count	   } */
 
 /**
  * -RAK-

--- a/src/main_loop.h
+++ b/src/main_loop.h
@@ -1,24 +1,14 @@
-#ifndef DUNGEON_H
-#define DUNGEON_H
+#ifndef MAIN_LOOP_H
+#define MAIN_LOOP_H
 /* there were not enough globals in variables.h */
 
 #include "types.h"
-
-#define DRAW_BOLT_DELAY 50
-#define DRAW_BALL_DELAY 30
-
-typedef long mm_type[6]; /* array [1..5] of long; */
 
 extern float regen_amount;      /* { Regenerate hp and mana} */
 extern boolean moria_flag;      /* { Next level when true  } */
 extern boolean reset_flag;      /* { Do not move creatures } */
 extern boolean search_flag;     /* { Player is searching   } */
 extern boolean teleport_flag;   /* { Handle telport traps  } */
-extern char s1[70];             /* { Summon item strings   } */
-extern char s2[70];             /* { Summon item strings   } */
-extern char s3[70];             /* { Summon item strings   } */
-extern char s4[70];             /* { Summon item strings   } */
-extern long i_summ_count;       /* { Summon item count	   } */
 
 #define DISPLAY_SIZE 20
 #define MOO_DISPLAY_SIZE 18
@@ -120,4 +110,4 @@ void dungeon();
 void py_bonuses(treasure_type *tobj, long factor);
 boolean delete_object(long y, long x);
 
-#endif /* DUNGEON_H */
+#endif /* MAIN_LOOP_H */

--- a/src/player.c
+++ b/src/player.c
@@ -9,7 +9,7 @@
 #include "configure.h"
 #include "constants.h"
 #include "debug.h"
-#include "dungeon.h"
+#include "main_loop.h"
 #include "magic.h"
 #include "pascal.h"
 #include "player.h"

--- a/src/player_move.c
+++ b/src/player_move.c
@@ -9,7 +9,7 @@
 #include "configure.h"
 #include "constants.h"
 #include "debug.h"
-#include "dungeon.h"
+#include "main_loop.h"
 #include "magic.h"
 #include "pascal.h"
 #include "player.h"

--- a/src/potions.c
+++ b/src/potions.c
@@ -9,7 +9,7 @@
 #include "configure.h"
 #include "constants.h"
 #include "debug.h"
-#include "dungeon.h"
+#include "main_loop.h"
 #include "magic.h"
 #include "pascal.h"
 #include "player.h"

--- a/src/scrolls.c
+++ b/src/scrolls.c
@@ -9,7 +9,7 @@
 #include "configure.h"
 #include "constants.h"
 #include "debug.h"
-#include "dungeon.h"
+#include "main_loop.h"
 #include "magic.h"
 #include "pascal.h"
 #include "player.h"

--- a/src/spells.c
+++ b/src/spells.c
@@ -12,7 +12,7 @@
 #include "configure.h"
 #include "constants.h"
 #include "debug.h"
-#include "dungeon.h"
+#include "main_loop.h"
 #include "magic.h"
 #include "pascal.h"
 #include "player.h"
@@ -33,6 +33,8 @@
 #include "spells.h"
 
 #define OBJ_BOLT_RANGE 18 /*{ Maximum range of bolts and balls	} */
+#define DRAW_BOLT_DELAY 50
+#define DRAW_BALL_DELAY 30
 
 static const treasure_type scare_monster = /* { Special trap	} */
     {"a strange rune",

--- a/src/staffs.c
+++ b/src/staffs.c
@@ -9,7 +9,7 @@
 #include "configure.h"
 #include "constants.h"
 #include "debug.h"
-#include "dungeon.h"
+#include "main_loop.h"
 #include "magic.h"
 #include "pascal.h"
 #include "player.h"

--- a/src/stores.c
+++ b/src/stores.c
@@ -13,7 +13,7 @@
 #include "kickout.h"
 #include "constants.h"
 #include "debug.h"
-#include "dungeon.h"
+#include "main_loop.h"
 #include "magic.h"
 #include "pascal.h"
 #include "player.h"

--- a/src/traps.c
+++ b/src/traps.c
@@ -12,7 +12,7 @@
 #include "configure.h"
 #include "constants.h"
 #include "debug.h"
-#include "dungeon.h"
+#include "main_loop.h"
 #include "magic.h"
 #include "pascal.h"
 #include "player.h"

--- a/src/wands.c
+++ b/src/wands.c
@@ -12,7 +12,7 @@
 #include "configure.h"
 #include "constants.h"
 #include "debug.h"
-#include "dungeon.h"
+#include "main_loop.h"
 #include "magic.h"
 #include "pascal.h"
 #include "player.h"

--- a/src/wizard.c
+++ b/src/wizard.c
@@ -12,7 +12,7 @@
 #include "configure.h"
 #include "constants.h"
 #include "debug.h"
-#include "dungeon.h"
+#include "main_loop.h"
 #include "magic.h"
 #include "pascal.h"
 #include "player.h"


### PR DESCRIPTION
dungeon.h contains the main loop, but also loads and loads of functions, making many files reference back to it. Cleaning it up makes the program more one-directional.

- [ ] Remove all `#include "main_loop.h"` except for main.c and main_loop.c